### PR TITLE
fix: raid plugin: raid status fix

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -57,7 +57,7 @@ const (
 	DefaultTelegrafInitImageName = "telegraf-init"
 	DefaultTelegrafInitImageTag  = "release-1.5.2"
 	DefaultTelegrafRaidImageName = "telegraf-raid-plugin"
-	DefaultTelegrafRaidImageTag  = "release-1.5.2"
+	DefaultTelegrafRaidImageTag  = "release-1.5.3"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {


### PR DESCRIPTION
1.raid 卡监控状态调整，对应调整下raid-plugin image tag：release-1.5.2 ==> release-1.5.3

**Does this PR need to be backport to the previous release branch?:**

- release/3.7

- release/3.6

/cc @zexi 
