### PR TITLE
Automated cherry pick of #462: fix(glance): s3 endpoint should use domain resolve

### DIFF
--- a/pkg/manager/component/glance.go
+++ b/pkg/manager/component/glance.go
@@ -132,7 +132,7 @@ func (m *glanceManager) setS3Config(oc *v1alpha1.OnecloudCluster) error {
 
 	//svc.Spec.ClusterIP
 	port := svc.Spec.Ports[0].Port
-	endpoint := fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, port)
+	endpoint := fmt.Sprintf("%s.%s:%d", svc.GetName(), svc.GetNamespace(), port)
 
 	var ak, sk string
 	// base64 decode


### PR DESCRIPTION
Cherry pick of #462 on release/3.7.

#462: fix(glance): s3 endpoint should use domain resolve