### PR TITLE
Automated cherry pick of #497: fix(cloudmon): report usage set timeout param

### DIFF
--- a/pkg/manager/component/cloudmon.go
+++ b/pkg/manager/component/cloudmon.go
@@ -160,7 +160,7 @@ func formateCloudmonNoProviderCommand(reportDur uint, timeout uint, reportInterv
 		return fmt.Sprintf("\necho '*/%d * * * * /opt/yunion/bin/cloudmon --config /etc/yunion/apigateway.conf %s --timeout %d 2>&1' > /etc/crontabs/root",
 			reportDur, command, timeout)
 	case "report-usage":
-		return fmt.Sprintf("\necho '*/%d * * * *  /opt/yunion/bin/cloudmon --config /etc/yunion/apigateway.conf %s timeout  %d  2>&1' >> /etc/crontabs/root",
+		return fmt.Sprintf("\necho '*/%d * * * *  /opt/yunion/bin/cloudmon --config /etc/yunion/apigateway.conf %s  --timeout  %d  2>&1' >> /etc/crontabs/root",
 			reportDur, command, timeout)
 	case "report-alertrecord":
 		return fmt.Sprintf("\necho '0 0 */%d * *  /opt/yunion/bin/cloudmon --config /etc/yunion/apigateway.conf %s --interval %d --timeout  %d 2>&1' >> /etc/crontabs/root",


### PR DESCRIPTION
Cherry pick of #497 on release/3.7.

#497: fix(cloudmon): report usage set timeout param