### PR TITLE
Automated cherry pick of #514: fix(host-image): read only bind mount /etc/resolv.conf and /etc/hosts

### DIFF
--- a/pkg/manager/component/host-image.go
+++ b/pkg/manager/component/host-image.go
@@ -46,8 +46,8 @@ func (m *hostImageManager) newHostPrivilegedDaemonSet(
 					Image: oc.Spec.HostImage.Image,
 					Command: []string{
 						"sh", "-c", fmt.Sprintf(`
-							mount --bind /etc/hosts %s/etc/hosts
-							mount --bind /etc/resolv.conf %s/etc/resolv.conf
+							mount --bind -o ro /etc/hosts %s/etc/hosts
+							mount --bind -o ro /etc/resolv.conf %s/etc/resolv.conf
 							mkdir -p %s/etc/yunion/common
 							mount --bind /etc/yunion/common %s/etc/yunion/common
 							mkdir -p %s/etc/yunion/pki


### PR DESCRIPTION
Cherry pick of #514 on release/3.8.

#514: fix(host-image): read only bind mount /etc/resolv.conf and /etc/hosts