### PR TITLE
Automated cherry pick of #548: fix: update host image tag to v1.0.3

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -48,7 +48,7 @@ const (
 	DefaultOvnImageTag  = DefaultOvnVersion + "-1"
 
 	DefaultHostImageName = "host-image"
-	DefaultHostImageTag  = "v1.0.2"
+	DefaultHostImageTag  = "v1.0.3"
 
 	DefaultInfluxdbImageVersion = "1.7.7"
 


### PR DESCRIPTION
Cherry pick of #548 on release/3.9.

#548: fix: update host image tag to v1.0.3