### PR TITLE
Automated cherry pick of #557: update telegraf-raid-plugin to 1.6.2

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -57,7 +57,7 @@ const (
 	DefaultTelegrafInitImageName = "telegraf-init"
 	DefaultTelegrafInitImageTag  = "release-1.5.2"
 	DefaultTelegrafRaidImageName = "telegraf-raid-plugin"
-	DefaultTelegrafRaidImageTag  = "release-1.6.1"
+	DefaultTelegrafRaidImageTag  = "release-1.6.2"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {


### PR DESCRIPTION
Cherry pick of #557 on release/3.7.

#557: update telegraf-raid-plugin to 1.6.2