### PR TITLE
Automated cherry pick of #583: fix: nginx api export timeout

### DIFF
--- a/pkg/manager/component/web.go
+++ b/pkg/manager/component/web.go
@@ -128,6 +128,7 @@ server {
         proxy_buffers   32 16k;
         proxy_busy_buffers_size 16k;
         proxy_temp_file_write_size 16k;
+        proxy_read_timeout 600;
     }
 
     location /api/v1/imageutils/upload {


### PR DESCRIPTION
Cherry pick of #583 on release/3.7.

#583: fix: nginx api export timeout