### PR TITLE
Automated cherry pick of #597: fix(notify): enable websocket plugin when ee enabled

### DIFF
--- a/pkg/manager/component/notify.go
+++ b/pkg/manager/component/notify.go
@@ -216,13 +216,16 @@ func (m *notifyManager) getDeployment(oc *v1alpha1.OnecloudCluster, cfg *v1alpha
 		newPluginC(NotifyPluginDingtalk),
 		newPluginC(NotifyPluginEmail),
 		newPluginC(NotifyPluginSmsAliyun),
-		newPluginC(NotifyPluginWebsocket),
 		newPluginC(NotifyPluginFeishu),
 		newPluginC(NotifyPluginFeishuRobot),
 		newPluginC(NotifyPluginDingtalkRobot),
 		newPluginCWithoutConf(NotifyPluginWorkwx),
 		newPluginCWithoutConf(NotifyPluginWorkwxRobot),
 		newPluginCWithoutConf(NotifyPluginWebhook),
+	}
+	isEE := IsEnterpriseEdition(oc)
+	if isEE {
+		pluginCs = append(pluginCs, newPluginC(NotifyPluginWebsocket))
 	}
 	spec := &deploy.Spec.Template.Spec
 	cs := spec.Containers


### PR DESCRIPTION
Cherry pick of #597 on release/3.9.

#597: fix(notify): enable websocket plugin when ee enabled