### PR TITLE
Automated cherry pick of #638: fix(host-image): update DefaultHostImageTag to v1.0.4

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -55,7 +55,7 @@ const (
 	DefaultNotifyPluginsImageName = "notify-plugins"
 
 	DefaultHostImageName = "host-image"
-	DefaultHostImageTag  = "v1.0.3"
+	DefaultHostImageTag  = "v1.0.4"
 
 	DefaultInfluxdbImageVersion = "1.7.7"
 


### PR DESCRIPTION
Cherry pick of #638 on release/3.9.

#638: fix(host-image): update DefaultHostImageTag to v1.0.4