### PR TITLE
Automated cherry pick of #649: fix(telegraf): use release-1.19.2-0 image

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -53,7 +53,7 @@ const (
 	DefaultInfluxdbImageVersion = "1.7.7"
 
 	DefaultTelegrafImageName     = "telegraf"
-	DefaultTelegrafImageTag      = "release-1.5.3"
+	DefaultTelegrafImageTag      = "release-1.19.2-0"
 	DefaultTelegrafInitImageName = "telegraf-init"
 	DefaultTelegrafInitImageTag  = "release-1.5.2"
 	DefaultTelegrafRaidImageName = "telegraf-raid-plugin"


### PR DESCRIPTION
Cherry pick of #649 on release/3.8.

#649: fix(telegraf): use release-1.19.2-0 image