### PR TITLE
Automated cherry pick of #658: fix: update DefaultTelegrafRaidImageTag to release-1.6.4

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -64,7 +64,7 @@ const (
 	DefaultTelegrafInitImageName = "telegraf-init"
 	DefaultTelegrafInitImageTag  = "release-1.5.2"
 	DefaultTelegrafRaidImageName = "telegraf-raid-plugin"
-	DefaultTelegrafRaidImageTag  = "release-1.6.3"
+	DefaultTelegrafRaidImageTag  = "release-1.6.4"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {


### PR DESCRIPTION
Cherry pick of #658 on master.

#658: fix: update DefaultTelegrafRaidImageTag to release-1.6.4