### PR TITLE
fix: enable clickhouse when host is set

### DIFF
--- a/pkg/manager/component/component.go
+++ b/pkg/manager/component/component.go
@@ -245,7 +245,7 @@ func (m *ComponentManager) syncConfigMap(
 			}
 		}
 	}
-	{
+	if len(oc.Spec.Clickhouse.Host) > 0 {
 		clickhouseConfig := f.getClickhouseConfig(clustercfg)
 		if clickhouseConfig != nil && IsEnterpriseEdition(oc) {
 			if err := EnsureClusterClickhouseUser(oc, *clickhouseConfig); err != nil {


### PR DESCRIPTION
fix: enable clickhouse when host is set