### PR TITLE
Automated cherry pick of #747: fix(operator): telegraf component uses release-1.19.2-1 tag which contains tini as entrypoint

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -53,7 +53,7 @@ const (
 	DefaultInfluxdbImageVersion = "1.7.7"
 
 	DefaultTelegrafImageName     = "telegraf"
-	DefaultTelegrafImageTag      = "release-1.19.2-0"
+	DefaultTelegrafImageTag      = "release-1.19.2-1"
 	DefaultTelegrafInitImageName = "telegraf-init"
 	DefaultTelegrafInitImageTag  = "release-1.19.2-0"
 	DefaultTelegrafRaidImageName = "telegraf-raid-plugin"

--- a/pkg/manager/component/telegraf.go
+++ b/pkg/manager/component/telegraf.go
@@ -64,7 +64,7 @@ func (m *telegrafManager) newTelegrafDaemonSet(
 						Value: hostRoot,
 					},
 				},
-				Command: []string{
+				Args: []string{
 					"/usr/bin/telegraf",
 					"-config", "/etc/telegraf/telegraf.conf",
 					"-config-directory", "/etc/telegraf/telegraf.d",


### PR DESCRIPTION
Cherry pick of #747 on release/3.8.

#747: fix(operator): telegraf component uses release-1.19.2-1 tag which contains tini as entrypoint