### PR TITLE
Automated cherry pick of #797: fix(operator): set EDITOR=vim env for climc component

### DIFF
--- a/pkg/manager/component/climc.go
+++ b/pkg/manager/component/climc.go
@@ -80,6 +80,10 @@ func GetRCAdminEnv(oc *v1alpha1.OnecloudCluster) []corev1.EnvVar {
 			Name:  "YUNION_INSECURE",
 			Value: "true",
 		},
+		{
+			Name:  "EDITOR",
+			Value: "vim",
+		},
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #797 on release/3.10.

#797: fix(operator): set EDITOR=vim env for climc component