### PR TITLE
Automated cherry pick of #961: fix(operator): running host-image on ubuntu 22.04

### DIFF
--- a/pkg/manager/component/host-image.go
+++ b/pkg/manager/component/host-image.go
@@ -58,7 +58,7 @@ func (m *hostImageManager) newHostPrivilegedDaemonSet(
 					Command: []string{
 						"sh", "-ce", fmt.Sprintf(`
 mkdir -p /etc/resolvconf/run && cp /etc/resolv.conf /etc/resolvconf/run
-mkdir -p /run/systemd/resolve && cp /etc/resolv.conf /run/systemd/resolve
+mkdir -p /run/systemd/resolve && cp /etc/resolv.conf /run/systemd/resolve && cp /etc/resolv.conf /run/systemd/resolve/stub-resolv.conf
 mount --bind -o ro /etc/hosts %s/etc/hosts
 test -d %s/run/systemd/resolve && mount --rbind /run/systemd/resolve %s/run/systemd/resolve
 mount --bind -o ro /etc/resolv.conf %s/etc/resolv.conf


### PR DESCRIPTION
Cherry pick of #961 on release/3.11.

#961: fix(operator): running host-image on ubuntu 22.04