### PR TITLE
Automated cherry pick of #975: fix(operator): smart_device health status alerting should use health_ok field

### DIFF
--- a/pkg/controller/onecloud_control.go
+++ b/pkg/controller/onecloud_control.go
@@ -1357,18 +1357,10 @@ func (c monitorComponent) getInitInfo() map[string]onecloud.CommonAlertTem {
 	smartDevTem := onecloud.CommonAlertTem{
 		Database:    "telegraf",
 		Measurement: "smart_device",
-		Field:       []string{"exit_status"},
+		Field:       []string{"health_ok"},
 		FieldFunc:   "last",
 		Comparator:  "==",
 		Threshold:   0,
-		Filters: []monitor.MetricQueryTag{
-			{
-				Key:       "health_ok",
-				Operator:  "=",
-				Value:     "false",
-				Condition: "AND",
-			},
-		},
 		Name:        "smart_device.exit_status",
 		Reduce:      "last",
 		Description: "监测磁盘健康状态",


### PR DESCRIPTION
Cherry pick of #975 on release/3.9.

#975: fix(operator): smart_device health status alerting should use health_ok field