### PR TITLE
Automated cherry pick of #1005: ffix(host-deployer): host deployer use host network

### DIFF
--- a/pkg/manager/component/host-deployer.go
+++ b/pkg/manager/component/host-deployer.go
@@ -101,7 +101,7 @@ func (m *hostDeployerManager) newHostPrivilegedDaemonSet(
 	// }
 	maxUnavailable := intstr.FromInt(999)
 	ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable = &maxUnavailable
-	ds.Spec.Template.Spec.HostNetwork = false
+	ds.Spec.Template.Spec.HostNetwork = true
 	return ds, nil
 }
 


### PR DESCRIPTION
Cherry pick of #1005 on master.

#1005: ffix(host-deployer): host deployer use host network