### PR TITLE
Automated cherry pick of #1008: fix(operator): generate configmap for host-deployer when PV is CMP

### DIFF
--- a/pkg/manager/component/host-deployer.go
+++ b/pkg/manager/component/host-deployer.go
@@ -38,6 +38,13 @@ func (m *hostDeployerManager) Sync(oc *v1alpha1.OnecloudCluster) error {
 	return syncComponent(m, oc, oc.Spec.HostDeployer.Disable, "")
 }
 
+func (m *hostDeployerManager) getConfigMap(oc *v1alpha1.OnecloudCluster, cfg *v1alpha1.OnecloudClusterConfig, zone string) (*corev1.ConfigMap, bool, error) {
+	if oc.Spec.ProductVersion == v1alpha1.ProductVersionCMP {
+		return newHostManager(m.ComponentManager).(*hostManager).getConfigMap(oc, cfg, zone)
+	}
+	return nil, false, nil
+}
+
 func (m *hostDeployerManager) getDaemonSet(oc *v1alpha1.OnecloudCluster, cfg *v1alpha1.OnecloudClusterConfig, zone string) (*apps.DaemonSet, error) {
 	return m.newHostPrivilegedDaemonSet(v1alpha1.HostDeployerComponentType, oc, cfg)
 }


### PR DESCRIPTION
Cherry pick of #1008 on master.

#1008: fix(operator): generate configmap for host-deployer when PV is CMP