### PR TITLE
Automated cherry pick of #1030: fix: regionDNS configmaps support in_cloud_only option

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/types.go
+++ b/pkg/apis/onecloud/v1alpha1/types.go
@@ -939,7 +939,8 @@ type RegionDNSProxy struct {
 
 type RegionDNSSpec struct {
 	DaemonSetSpec
-	Proxies []RegionDNSProxy `json:"proxies"`
+	Proxies     []RegionDNSProxy `json:"proxies"`
+	InCloudOnly bool             `json:"in_cloud_only"`
 }
 
 type RegionDNSStatus struct {


### PR DESCRIPTION
Cherry pick of #1030 on release/3.11.

#1030: fix: regionDNS configmaps support in_cloud_only option