### PR TITLE
Automated cherry pick of #1032: fix(operator): set NodeSelector to OnecloudControllerLabelKey for etcd component

### DIFF
--- a/pkg/manager/component/etcd.go
+++ b/pkg/manager/component/etcd.go
@@ -403,7 +403,7 @@ func (m *etcdManager) customPodSpec(pod *corev1.Pod, mb *etcdutil.Member, state,
 		pod.Spec.NodeSelector = make(map[string]string)
 	}
 	if !controller.DisableNodeSelectorController {
-		pod.Spec.NodeSelector[constants.LabelNodeRoleMaster] = ""
+		pod.Spec.NodeSelector[constants.OnecloudControllerLabelKey] = "enable"
 	}
 	if pod.Spec.Affinity == nil {
 		pod.Spec.Affinity = new(corev1.Affinity)


### PR DESCRIPTION
Cherry pick of #1032 on release/3.11.

#1032: fix(operator): set NodeSelector to OnecloudControllerLabelKey for etcd component