### PR TITLE
fix(operator): enable cloudproxy when ProductVersion is edge

### DIFF
--- a/pkg/manager/component/cloudproxyserver.go
+++ b/pkg/manager/component/cloudproxyserver.go
@@ -41,6 +41,7 @@ func (m *cloudproxyManager) getProductVersions() []v1alpha1.ProductVersion {
 	return []v1alpha1.ProductVersion{
 		v1alpha1.ProductVersionFullStack,
 		v1alpha1.ProductVersionCMP,
+		v1alpha1.ProductVersionEdge,
 	}
 }
 


### PR DESCRIPTION
相关问题：
- https://github.com/yunionio/cloudpods/issues/19245
- https://github.com/yunionio/cloudpods/issues/19156