### PR TITLE
Automated cherry pick of #1034: fix(operator): enable cloudproxy when ProductVersion is edge

### DIFF
--- a/pkg/manager/component/cloudproxyserver.go
+++ b/pkg/manager/component/cloudproxyserver.go
@@ -41,6 +41,7 @@ func (m *cloudproxyManager) getProductVersions() []v1alpha1.ProductVersion {
 	return []v1alpha1.ProductVersion{
 		v1alpha1.ProductVersionFullStack,
 		v1alpha1.ProductVersionCMP,
+		v1alpha1.ProductVersionEdge,
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #1034 on release/3.11.

#1034: fix(operator): enable cloudproxy when ProductVersion is edge