### PR TITLE
Automated cherry pick of #1037: fix(operator): use bidirectional mount for telegraf component

### DIFF
--- a/pkg/manager/component/telegraf.go
+++ b/pkg/manager/component/telegraf.go
@@ -177,14 +177,16 @@ func NewTelegrafVolume(
 			MountPath: path.Join(hostRoot, "/sys"),
 		},
 		{
-			Name:      "root",
-			ReadOnly:  true,
-			MountPath: hostRoot,
+			Name:             "root",
+			ReadOnly:         true,
+			MountPath:        hostRoot,
+			MountPropagation: &bidirectional,
 		},
 		{
-			Name:      "run",
-			ReadOnly:  false,
-			MountPath: "/var/run",
+			Name:             "run",
+			ReadOnly:         false,
+			MountPath:        "/var/run",
+			MountPropagation: &bidirectional,
 		},
 		{
 			Name:      "dev",


### PR DESCRIPTION
Cherry pick of #1037 on master.

#1037: fix(operator): use bidirectional mount for telegraf component