### PR TITLE
Revert "fix(operator): use bidirectional mount for telegraf component"

### DIFF
--- a/pkg/manager/component/telegraf.go
+++ b/pkg/manager/component/telegraf.go
@@ -177,16 +177,14 @@ func NewTelegrafVolume(
 			MountPath: path.Join(hostRoot, "/sys"),
 		},
 		{
-			Name:             "root",
-			ReadOnly:         true,
-			MountPath:        hostRoot,
-			MountPropagation: &bidirectional,
+			Name:      "root",
+			ReadOnly:  true,
+			MountPath: hostRoot,
 		},
 		{
-			Name:             "run",
-			ReadOnly:         false,
-			MountPath:        "/var/run",
-			MountPropagation: &bidirectional,
+			Name:      "run",
+			ReadOnly:  false,
+			MountPath: "/var/run",
 		},
 		{
 			Name:      "dev",


### PR DESCRIPTION
This reverts commit ac00df646a1f671cee8943cc86e5e360cf2dd9ea.