### PR TITLE
解决3.8开源版自动启用autoupdate的 bug（预期不启用）

### DIFF
--- a/pkg/manager/component/autoupdate.go
+++ b/pkg/manager/component/autoupdate.go
@@ -39,6 +39,9 @@ func (m *autoUpdateManager) getComponentType() v1alpha1.ComponentType {
 }
 
 func (m *autoUpdateManager) Sync(oc *v1alpha1.OnecloudCluster) error {
+	if !IsEnterpriseEdition(oc) {
+		return nil
+	}
 	return syncComponent(m, oc, oc.Spec.AutoUpdate.Disable, "")
 }
 


### PR DESCRIPTION
解决3.8开源版自动启用autoupdate的 bug（预期不启用）