### PR TITLE
Automated cherry pick of #1117: fix: disable lb feature when product version is baremetal

### DIFF
--- a/pkg/service-init/component/yunoinconf.go
+++ b/pkg/service-init/component/yunoinconf.go
@@ -270,7 +270,6 @@ func (pc *yunionconfPC) SystemInit(oc *v1alpha1.OnecloudCluster) error {
 			"onecloud",
 			"onestack",
 			"baremetal",
-			"lb",
 		}
 		setupKeysFull := []string{}
 		setupKeysFull = append(setupKeysFull, setupKeysCmp...)


### PR DESCRIPTION
Cherry pick of #1117 on release/3.11.6.

#1117: fix: disable lb feature when product version is baremetal