### PR TITLE
Automated cherry pick of #1122: fix: disable onestack feature of baremetal product version

### DIFF
--- a/pkg/service-init/component/yunoinconf.go
+++ b/pkg/service-init/component/yunoinconf.go
@@ -268,7 +268,6 @@ func (pc *yunionconfPC) SystemInit(oc *v1alpha1.OnecloudCluster) error {
 		}
 		setupKeysBaremetal := []string{
 			"onecloud",
-			"onestack",
 			"baremetal",
 		}
 		setupKeysFull := []string{}


### PR DESCRIPTION
Cherry pick of #1122 on release/3.11.6.

#1122: fix: disable onestack feature of baremetal product version