### PR TITLE
Automated cherry pick of #1190: fix(operator): not disable yunionagent when edition is ce/support

### DIFF
--- a/pkg/manager/component/yunionagent.go
+++ b/pkg/manager/component/yunionagent.go
@@ -55,7 +55,7 @@ func (m *yunionagentManager) GetComponentType() v1alpha1.ComponentType {
 }
 
 func (m *yunionagentManager) IsDisabled(oc *v1alpha1.OnecloudCluster) bool {
-	return oc.Spec.Yunionagent.Disable || !IsEnterpriseEdition(oc)
+	return oc.Spec.Yunionagent.Disable || !IsEEOrESEEdition(oc)
 }
 
 func (m *yunionagentManager) GetServiceName() string {


### PR DESCRIPTION
Cherry pick of #1190 on release/3.11.9.

#1190: fix(operator): not disable yunionagent when edition is ce/support