### PR TITLE
Automated cherry pick of #1209: fix: adjust nginx default client_header_timeout

### DIFF
--- a/pkg/service-init/component/web.go
+++ b/pkg/service-init/component/web.go
@@ -97,7 +97,7 @@ server {
     client_max_body_size 8m;
     large_client_header_buffers 2 16k;
     client_body_timeout 20s;
-    client_header_timeout 120s;
+    client_header_timeout 20s;
 
 {{.EditionConfig}}
 


### PR DESCRIPTION
Cherry pick of #1209 on release/3.11.

#1209: fix: adjust nginx default client_header_timeout