### PR TITLE
Automated cherry pick of #1271: chore: bump host-health-version

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -67,7 +67,7 @@ const (
 	DefaultHostImageTag  = "v1.0.7"
 
 	DefaultHostHealthName = "host-health"
-	DefaultHostHealthTag  = "v0.0.1"
+	DefaultHostHealthTag  = "v0.0.3"
 
 	DefaultInfluxdbImageVersion = "1.7.7"
 


### PR DESCRIPTION
Cherry pick of #1271 on release/4.0.

#1271: chore: bump host-health-version