### PR TITLE
Automated cherry pick of #1274: chore: bump telegraf version to release-1.19.2-10

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -74,7 +74,7 @@ const (
 	DefaultVictoriaMetricsImageVersion = "v1.95.1"
 
 	DefaultTelegrafImageName     = "telegraf"
-	DefaultTelegrafImageTag      = "release-1.19.2-9"
+	DefaultTelegrafImageTag      = "release-1.19.2-10"
 	DefaultTelegrafInitImageName = "telegraf-init"
 	DefaultTelegrafInitImageTag  = "release-1.19.2-0"
 	DefaultTelegrafRaidImageName = "telegraf-raid-plugin"


### PR DESCRIPTION
Cherry pick of #1274 on release/4.0.0.

#1274: chore: bump telegraf version to release-1.19.2-10