### PR TITLE
Automated cherry pick of #1304: fix(operator): disable the apimap service defaultly

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -223,6 +223,8 @@ func SetDefaults_OnecloudClusterSpec(obj *OnecloudClusterSpec, isEE bool, isEEOr
 			spec.Supported, isEE,
 		))
 	}
+	// disable the apimap service defaultly
+	obj.APIMap.Disable = true
 
 	// CE or EE parts
 	for cType, spec := range map[ComponentType]*hyperImagePair{


### PR DESCRIPTION
Cherry pick of #1304 on release/4.0.

#1304: fix(operator): disable the apimap service defaultly