### PR TITLE
Automated cherry pick of #1331: fix(operator): enable autoupdate service for LightEdige product version

### DIFF
--- a/pkg/manager/component/autoupdate.go
+++ b/pkg/manager/component/autoupdate.go
@@ -42,6 +42,7 @@ func (m *autoUpdateManager) getProductVersions() []v1alpha1.ProductVersion {
 		v1alpha1.ProductVersionFullStack,
 		v1alpha1.ProductVersionCMP,
 		v1alpha1.ProductVersionEdge,
+		v1alpha1.ProductVersionLightEdge,
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #1331 on release/4.0.

#1331: fix(operator): enable autoupdate service for LightEdige product version