### PR TITLE
fix: honor CommonAlertTem.From for nodata alerts

### DIFF
--- a/pkg/controller/onecloud_control.go
+++ b/pkg/controller/onecloud_control.go
@@ -1500,7 +1500,7 @@ func (c monitorComponent) getInitInfo() map[string]onecloud.CommonAlertTem {
 		Name:          "system.uptime",
 		Reduce:        "last",
 		ConditionType: "nodata_query",
-		From:          "3m",
+		From:          "10m",
 		Interval:      "1m",
 		Description:   "监测节点启动时间",
 		Level:         "important",

--- a/pkg/util/onecloud/onecloud.go
+++ b/pkg/util/onecloud/onecloud.go
@@ -882,6 +882,9 @@ func containDiffsWithRtnAlert(input monitorapi.CommonAlertUpdateInput, rtnAlert 
 		if details[i].Comparator != inputQuery[i].Comparator {
 			return conDiff, nil
 		}
+		if condi.Query.From != inputQuery[i].From {
+			return conDiff, nil
+		}
 		oldSel := jsonutils.Marshal(&condi.Query.Model.Selects)
 		newSel := jsonutils.Marshal(&inputQuery[i].Model.Selects)
 		if !oldSel.Equals(newSel) {
@@ -948,6 +951,13 @@ func newCommonalertQuery(tem CommonAlertTem) monitorapi.CommonAlertQuery {
 	alertQ := new(monitorapi.AlertQuery)
 	alertQ.Model = metricQ
 	alertQ.From = "60m"
+	if tem.ConditionType == monitorapi.METRIC_QUERY_TYPE_NO_DATA {
+		from := tem.From
+		if from == "" {
+			from = "10m"
+		}
+		alertQ.From = from
+	}
 
 	commonAlert := monitorapi.CommonAlertQuery{
 		AlertQuery: alertQ,


### PR DESCRIPTION
Use template From (default 10m) instead of fixed 60m for nodata queries, detect From diffs on update, and align system.uptime window to 10m.