### PR TITLE
fix: respect configured etcd busybox image

### DIFF
--- a/pkg/manager/component/etcd.go
+++ b/pkg/manager/component/etcd.go
@@ -395,8 +395,10 @@ func (m *etcdManager) customPodSpec(pod *corev1.Pod, mb *etcdutil.Member, state,
 	shareProcessNamespace := true
 	pod.Spec.ShareProcessNamespace = &shareProcessNamespace
 
-	pod.Spec.InitContainers[0].Image = fmt.Sprintf("%s:%s",
-		path.Join(imageRepository, constants.BusyboxImageName), constants.BusyboxImageVersion)
+	if m.oc.Spec.Etcd.Pod == nil || len(m.oc.Spec.Etcd.Pod.BusyboxImage) == 0 {
+		pod.Spec.InitContainers[0].Image = fmt.Sprintf("%s:%s",
+			path.Join(imageRepository, constants.BusyboxImageName), constants.BusyboxImageVersion)
+	}
 
 	pod.Spec.DNSPolicy = corev1.DNSClusterFirst
 	if pod.Spec.Tolerations == nil {


### PR DESCRIPTION
## What changed

Keep the etcd init container image supplied through `spec.etcd.pod.busyboxImage` instead of always replacing it with the repository-wide BusyBox default.

## Why

`NewEtcdPod` already applies the configured `PodPolicy.BusyboxImage`, but `customPodSpec` unconditionally overwrote it afterwards. This made architecture-specific and private-registry deployments ignore their explicit image mapping and attempt to pull a hard-coded tag.

## Impact

Existing deployments without an explicit BusyBox image keep the current default behavior. Deployments that set `busyboxImage` now receive the requested image in newly created etcd pods.

## Validation

- `gofmt` and `git diff --check` passed.
- The native RISC-V image pipeline applies this patch before compiling the operator and performs a runtime `--help` smoke test.
- The local package test cannot compile the pinned upstream vendor tree on the current macOS host because `SNetInterface.FlushAddrs` is absent in the vendored dependency; this failure is unrelated to this change.
