### PR TITLE
fix: use stable batch/v1 CronJobs

### DIFF
--- a/pkg/controller/cluster/onecloud_cluster_controller.go
+++ b/pkg/controller/cluster/onecloud_cluster_controller.go
@@ -105,7 +105,7 @@ func NewController(
 	ingInformer := dynamicInformerFactory.ForResource(cv.GetIngressGVR())
 
 	dsInformer := kubeInformerFactory.Apps().V1().DaemonSets()
-	cronInformer := kubeInformerFactory.Batch().V1beta1().CronJobs()
+	cronInformer := kubeInformerFactory.Batch().V1().CronJobs()
 
 	ocControl := controller.NewClusterControl(cli, ocInformer.Lister(), recorder)
 	deployControl := controller.NewDeploymentControl(kubeCli, deployInformer.Lister(), recorder)

--- a/pkg/controller/cronjob_control.go
+++ b/pkg/controller/cronjob_control.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	batchv1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/listers/batch/v1beta1"
+	batchlisters "k8s.io/client-go/listers/batch/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog"
@@ -26,11 +26,11 @@ type CronJobControlInterface interface {
 type cronJobControl struct {
 	*baseControl
 	kubeCli       kubernetes.Interface
-	cronJobLister v1beta1.CronJobLister
+	cronJobLister batchlisters.CronJobLister
 }
 
 func NewCronJobControl(
-	kubeCli kubernetes.Interface, cronJobLister v1beta1.CronJobLister, recorder record.EventRecorder,
+	kubeCli kubernetes.Interface, cronJobLister batchlisters.CronJobLister, recorder record.EventRecorder,
 ) CronJobControlInterface {
 	return &cronJobControl{newBaseControl("CronJob", recorder), kubeCli, cronJobLister}
 }
@@ -38,7 +38,7 @@ func NewCronJobControl(
 func (c *cronJobControl) CreateCronJob(
 	oc *v1alpha1.OnecloudCluster, cronJob *batchv1.CronJob,
 ) error {
-	_, err := c.kubeCli.BatchV1beta1().CronJobs(oc.Namespace).Create(context.Background(), cronJob, v1.CreateOptions{})
+	_, err := c.kubeCli.BatchV1().CronJobs(oc.Namespace).Create(context.Background(), cronJob, v1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		return err
 	}
@@ -56,7 +56,7 @@ func (c *cronJobControl) UpdateCronJob(
 	var cronJobSpec = cronJob.Spec.DeepCopy()
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var updateErr error
-		newCronJob, updateErr = c.kubeCli.BatchV1beta1().CronJobs(ns).Update(context.Background(), cronJob, v1.UpdateOptions{})
+		newCronJob, updateErr = c.kubeCli.BatchV1().CronJobs(ns).Update(context.Background(), cronJob, v1.UpdateOptions{})
 		if updateErr == nil {
 			klog.Infof("OnecloudCluster: [%s/%s]'s CronJob: [%s/%s] updated successfully", ns, ocName, ns, cronJobName)
 			return nil
@@ -80,7 +80,7 @@ func (c *cronJobControl) UpdateCronJob(
 func (c *cronJobControl) DeleteCronJob(
 	oc *v1alpha1.OnecloudCluster, cronJobName string,
 ) error {
-	err := c.kubeCli.BatchV1beta1().CronJobs(oc.Namespace).Delete(context.Background(), cronJobName, v1.DeleteOptions{})
+	err := c.kubeCli.BatchV1().CronJobs(oc.Namespace).Delete(context.Background(), cronJobName, v1.DeleteOptions{})
 	c.RecordDeleteEvent(oc, newFakeObject(cronJobName), err)
 	return err
 }

--- a/pkg/manager/component/cloudmon.go
+++ b/pkg/manager/component/cloudmon.go
@@ -45,7 +45,7 @@ func (m *cloudmonManager) ensureOldCronjobsDeleted(oc *v1alpha1.OnecloudCluster)
 		v1alpha1.CloudmonPingComponentType, v1alpha1.CloudmonReportHostComponentType,
 		v1alpha1.CloudmonReportServerComponentType, v1alpha1.CloudmonReportUsageComponentType,
 	} {
-		if _, err := m.kubeCli.BatchV1beta1().CronJobs(oc.GetNamespace()).
+		if _, err := m.kubeCli.BatchV1().CronJobs(oc.GetNamespace()).
 			Get(context.Background(), controller.NewClusterComponentName(oc.GetName(), componentType), metav1.GetOptions{}); err != nil && !errors.IsNotFound(err) {
 			return err
 		} else if err == nil {

--- a/pkg/manager/component/component.go
+++ b/pkg/manager/component/component.go
@@ -19,8 +19,7 @@ import (
 	"fmt"
 
 	apps "k8s.io/api/apps/v1"
-	jobbatchv1 "k8s.io/api/batch/v1"
-	batchv1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -30,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	appv1 "k8s.io/client-go/listers/apps/v1"
-	batchlisters "k8s.io/client-go/listers/batch/v1beta1"
+	batchlisters "k8s.io/client-go/listers/batch/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
@@ -1330,7 +1329,7 @@ func (m *ComponentManager) newCronJob(
 					Labels:      appLabel.Labels(),
 					Annotations: podAnnotations,
 				},
-				Spec: jobbatchv1.JobSpec{
+				Spec: batchv1.JobSpec{
 					// Selector: appLabel.LabelSelector(),
 					BackoffLimit: &jobSpecBackoffLimit,
 					Template: corev1.PodTemplateSpec{

--- a/pkg/manager/component/sync.go
+++ b/pkg/manager/component/sync.go
@@ -17,7 +17,7 @@ package component
 import (
 	"github.com/pkg/errors"
 	apps "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog"

--- a/pkg/manager/component/utils.go
+++ b/pkg/manager/component/utils.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	apps "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
Kubernetes removed the batch/v1beta1 CronJob API in v1.25. The old informer never syncs on current clusters, which prevents OnecloudCluster reconciliation from progressing after Keystone.

This switches CronJob types, clients, informers, and listers to the stable batch/v1 API.

Validation:
- `make VERSION=test GOARCH=arm64 BIN_DIR=/tmp/operator-build onecloud-operator`
- Kubernetes v1.36.4 runtime validation on a two-node openRuyi riscv64 cluster