### PR TITLE
Automated cherry pick of #1566: fix: update host-image to v1.0.9

### DIFF
--- a/pkg/apis/onecloud/v1alpha1/defaults.go
+++ b/pkg/apis/onecloud/v1alpha1/defaults.go
@@ -63,7 +63,7 @@ const (
 	DefaultNotifyPluginsImageName = "notify-plugins"
 
 	DefaultHostImageName = "host-image"
-	DefaultHostImageTag  = "v1.0.8"
+	DefaultHostImageTag  = "v1.0.9"
 
 	DefaultHostHealthName = "host-health"
 	DefaultHostHealthTag  = "v0.0.4"


### PR DESCRIPTION
Cherry pick of #1566 on release/4.0.4.

#1566: fix: update host-image to v1.0.9